### PR TITLE
Release 2.1.1: Fixes bad packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.tradeshift</groupId>
   <artifactId>tradeshift-ubl-examples</artifactId>
   <packaging>bundle</packaging>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
   <name>OASIS Universal Business Language examples</name>
   <url>http://docs.oasis-open.org/ubl/os-UBL-2.1/UBL-2.1.html</url>
   <description>


### PR DESCRIPTION
The 2.1.0 release did for some unexplained reason not contain the actual
content in the jar file. This patch release fixes that.

@wandenberg @caspertradeshift 